### PR TITLE
Remove draft state of RFC-1 & RFC-2

### DIFF
--- a/text/0001-rfc-process.md
+++ b/text/0001-rfc-process.md
@@ -1,7 +1,5 @@
 # 0001-rfc-process
 
-# THIS RFC IS STILL IN DRAFT MODE
-
 - Title: rfc-process
 - Authors: [joltz](mailto:joltz@protonmail.com), [yeastplume](mailto:yeastplume@protonmail.com), [lehnberg](mailto:daniel.lehnberg@protonmail.com)
 - Start date: June 21st, 2019

--- a/text/0002-grin-governance.md
+++ b/text/0002-grin-governance.md
@@ -1,14 +1,10 @@
 # 0002-grin-governance
 
-```
 - Title: grin-governance
-- Status: Draft
 - Authors: Daniel Lehnberg (daniel.lehnberg@protonmail.com),
            Michael Cordner (yeastplume@protonmail.com)
 - Start date: June 24th, 2019
-- Related issue: [URL to any related github issue]
-
-```
+- Related issue: [/grin-pm/#167](https://github.com/mimblewimble/grin-pm/issues/167) 
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
As per recent decisions:

https://github.com/mimblewimble/grin-pm/blob/master/notes/20190716-meeting-governance.md#decision-introduce-rfc-process

https://github.com/mimblewimble/grin-pm/blob/master/notes/20190716-meeting-governance.md#decision-establish-sub-teams