### PR TITLE
Variable Size Kernels

### DIFF
--- a/text/0000-variable-size-kernels.md
+++ b/text/0000-variable-size-kernels.md
@@ -123,5 +123,9 @@ One motivation for "variable size kernels" is to allow for new kernel variants t
 [references]: #references
 
 * [RFC 0000-relative-kernels][0] [fix link once RFC merged]
+* [PR #2734 (Support for variable size MMRs)][1]
+* [PR #2824 (Protocol version support)][2]
 
 [0]: https://github.com/mimblewimble/grin-rfcs/blob/master/text/0000-relative-kernels.md
+[1]: https://github.com/mimblewimble/grin/pull/2734
+[2]: https://github.com/mimblewimble/grin/pull/2824

--- a/text/0000-variable-size-kernels.md
+++ b/text/0000-variable-size-kernels.md
@@ -29,6 +29,8 @@ These changes affect serialization/deserialization of transaction kernels. Kerne
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
+#### Protocol Version 1 (Previous Version)
+
 In protocol version 1 all transaction kernels are serialized using the same structure, regardless of kernel variant. All kernels include 8 bytes for the fee and 8 bytes for the lock_height, even if unused.
 
 ```
@@ -49,9 +51,9 @@ The initial feature byte would determine the number of subsequent bytes to read 
 
 This would always be followed by a fixed 32 bytes for the excess commitment and 64 bytes for the kernel signature.
 
-----
+#### Protocol Version 2 (Current Version)
 
-Proposed plain kernel (protocol version 2) -
+Plain kernel, includes fee.
 
 ```
 features (1 byte) | fee (8 bytes) | excess (32 bytes) | signature (64 bytes)
@@ -59,7 +61,7 @@ features (1 byte) | fee (8 bytes) | excess (32 bytes) | signature (64 bytes)
 00 | 00 00 00 00 01 f7 8a 40 | 08 b1 ... 22 d8 | 33 11 ... b9 69
 ```
 
-Proposed coinbase kernel (protocol version 2) -
+Coinbase kernel, no fee, no lock height.
 
 ```
 features (1 byte) | excess (32 bytes) | signature (64 bytes)
@@ -67,7 +69,7 @@ features (1 byte) | excess (32 bytes) | signature (64 bytes)
 01 | 08 b2 ... 15 36 | 08 14 ... 98 96
 ```
 
-Proposed height locked kernel (protocol version 2) -
+Height locked kernel, include fee and lock height.
 
 ```
 features (1 byte) | fee (8 bytes) | lock_height (8 bytes) | excess (32 bytes) | signature (64 bytes)
@@ -91,9 +93,9 @@ Each node maintains a local kernel MMR - but this is also used to generate txhas
 
 #### Wallet Compatibility
 
-Interactive transaction building involves passing a transaction "slate" around. This includes a json serialized representation of the transaction.
+Interactive transaction building involves a transaction "slate" passed between parties. This includes a json serialized representation of the transaction.
 
-To minimize compatibility issues between walets we are not planning to change this json format or structure. Transaction kernels will continue to be translated to a single consistent json format, always including values for both fee and lock_height, regardless of feature variant. For example plain kernels will always have lock_height of 0 and coinbase kernels will always have 0 fee. This is consistent with the current "v2" slate.
+To minimize compatibility issues between wallets we have maintained this existing json format. Transaction kernels are represented in a single consistent json format, with fee and lock_height both included, regardless of kernel variant. Plain kernels have an associated lock_height of 0 and coinbase kernels include a 0 fee. This is consistent with the current "v2" slate.
 
 ```
 "kernels": [
@@ -103,21 +105,15 @@ To minimize compatibility issues between walets we are not planning to change th
 	"lock_height": "0",
 	"excess": "08b1...22d8",
 	"excess_sig": "3311...b969"
-  }
+  },
+  ...
 ]
 ```
-
-# Rationale and alternatives
-[rationale-and-alternatives]: #rationale-and-alternatives
-
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
 
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-One motivation for "variable size kernels" is to allow for new kernel variants to be introduced in the future. One concrete exampe of this is the proposal for [relative kernels][0]. Kernels of this feature variant will have an associated reference to a prior kernel and the existing "fixed size" binary serialization format does not provide the flexibility to include this additional data.
+Support for variable size kernels allows new kernel variants to be introduced in the future. One concrete exampe of this is [relative kernels][0]. Kernels with relative lock heights will have an associated reference to a prior kernel in addition to a lock height based on that prior kernel.
 
 # References
 [references]: #references

--- a/text/0000-variable-size-kernels.md
+++ b/text/0000-variable-size-kernels.md
@@ -123,9 +123,11 @@ One motivation for "variable size kernels" is to allow for new kernel variants t
 [references]: #references
 
 * [RFC 0000-relative-kernels][0] [fix link once RFC merged]
-* [PR #2734 (Support for variable size MMRs)][1]
-* [PR #2824 (Protocol version support)][2]
+* [PR #2734 Support for variable size MMRs][1]
+* [PR #2824 Protocol version support][2]
+* [PR #2859 Kernel feature variants][3]
 
 [0]: https://github.com/mimblewimble/grin-rfcs/blob/master/text/0000-relative-kernels.md
 [1]: https://github.com/mimblewimble/grin/pull/2734
 [2]: https://github.com/mimblewimble/grin/pull/2824
+[3]: https://github.com/mimblewimble/grin/pull/2859

--- a/text/0000-variable-size-kernels.md
+++ b/text/0000-variable-size-kernels.md
@@ -106,7 +106,7 @@ Each node has a "db" protocol version. All entries in the db serialize/deseriali
 
 ##### Kernel MMR storage (and txhashset fast sync)
 
-[wip]
+[wip - need to discuss how to handle txhashset fast sync support]
 
 #### Wallet Compatibility
 

--- a/text/0000-variable-size-kernels.md
+++ b/text/0000-variable-size-kernels.md
@@ -77,19 +77,36 @@ features (1 byte) | fee (8 bytes) | lock_height (8 bytes) | excess (32 bytes) | 
 02 | 00 00 00 00 00 6a cf c0 | 00 00 00 00 00 00 04 14 | 09 4d ... bb 9a | 09 c7 ... bd 54
 ```
 
-----
-
 #### Backward Compatibility (Protocol Version Support)
 
-[wip] Discuss compatibility between nodes across protocol version 1 and protocol version 2. Both for transaction and block p2p messages and the less flexible heavyweight txhashset.zip
+##### Network p2p messages
 
-How do we structure compatibility rules here to ensure nodes can still successfully communicate if bytes appear to be missing etc.
+The following p2p messages include serialized transaction kernels -
 
-We also need to account for in-place migration. Full blocks are stored in the local database.
+* transaction
+* full block
+* compact block (incl. coinbase kernel)
 
-Each node maintains a local kernel MMR - but this is also used to generate txhashset.zip which is sent to other nodes, so not limited to local node.
+Each node has a "local" protocol version. Nodes exchange protocol versions during the initial handshake when setting up a connection.
 
-----
+If both nodes are running protocol version 2 then no translation is required and transaction kernels can be serialized using protocl version 2.
+
+If both nodes are running protocol version 1 then again no translation is required.
+
+The complexity arises when one node is running protocol version 2 and the other node is running protocol version 1.
+
+* Node A: protocol version 2
+* Node B protocol version 1
+
+Node B will broadcast transactions and blocks using protocol version 1. Node A will need to use the previous protocol version and not the local version when deserializing these messages. Node A will need to ensure anything broadcast to Node B is compatible with protocol version 1. In both cases node A is responsible for translating to and from the previous protocol version.
+
+##### Local db storage
+
+Each node has a "db" protocol version. All entries in the db serialize/deserialize using that protocol version. Nodes support a process for local migration of data. On startup the db is inspected and if necessary a migration is performed upgrading all entries in the db to the latest protocol version. This process can be disabled locally to allow nodes to run against old databases without upgrading the protocol version. This is useful in cases where nodes do not wish to immediately upgrade the db, allowing for previous versions of code to run without problems.
+
+##### Kernel MMR storage (and txhashset fast sync)
+
+[wip]
 
 #### Wallet Compatibility
 

--- a/text/0000-variable-size-kernels.md
+++ b/text/0000-variable-size-kernels.md
@@ -1,7 +1,7 @@
 
 - Title: variable-size-kernels
 - Authors: [Antioch Peverell](mailto:apeverell@protonmail.com)
-- Start date : Aug 13, 2019
+- Start date: Aug 13, 2019
 - RFC PR: Edit if merged: [mimblewimble/grin-rfcs#0000](https://github.com/mimblewimble/grin-rfcs/pull/0000)
 - Tracking issue: [Edit if merged with link to tracking github issue]
 
@@ -20,7 +20,7 @@ We were originally including both fee and lock_height on _every_ kernel in the b
 # Community-level explanation
 [community-level-explanation]: #community-level-explanation
 
-Each transaction kernel variant may have associated data. For example height locked kernels include an associated lock height and non-coinbase kernels have an associated fee. Each kernel variant serializes to a fixed size in bytes but this size may be different for each kernel variants. This allows kernels to be serialized efficiently and provides flexibility to introduce new kernel variants that have additional associated data in the future.
+Each transaction kernel variant may have associated data. For example, height locked kernels include an associated lock height and non-coinbase kernels have an associated fee. Each kernel variant serializes to a fixed size in bytes but this size may be different for each kernel variants. This allows kernels to be serialized efficiently and provides flexibility to introduce new kernel variants that have additional associated data in the future.
 
 A plain kernel is 105 bytes compared to 113 bytes for a height locked kernel. Omitting the lock height from plain kernels saves approximately 7% in kernel storage costs.
 
@@ -89,7 +89,7 @@ The following p2p messages include serialized transaction kernels -
 
 Each node has a "local" protocol version. Nodes exchange protocol versions during the initial handshake when setting up a connection.
 
-If both nodes are running protocol version 2 then no translation is required and transaction kernels can be serialized using protocl version 2.
+If both nodes are running protocol version 2 then no translation is required and transaction kernels can be serialized using protocol version 2.
 
 If both nodes are running protocol version 1 then again no translation is required.
 
@@ -110,7 +110,7 @@ Node A will need to ensure anything broadcast to Node B is compatible with proto
 
 #### Local db storage
 
-Each node has a "db" protocol version. All entries in the db serialize/deserialize using that protocol version. Nodes support a process for local migration of data. On startup the db is inspected and if necessary a migration is performed upgrading all entries in the db to the latest protocol version. This process can be disabled locally to allow nodes to run against old databases without upgrading the protocol version. This is useful in cases where nodes do not wish to immediately upgrade the db, allowing for previous versions of code to run without problems.
+Each node has a "db" protocol version. All entries in the db serialize/deserialize using that protocol version. Nodes support a process for local migration of data. On startup, the db is inspected and if necessary a migration is performed upgrading all entries in the db to the latest protocol version. This process can be disabled locally to allow nodes to run against old databases without upgrading the protocol version. This is useful in cases where nodes do not wish to immediately upgrade the db, allowing for previous versions of code to run without problems.
 
 #### Kernel MMR storage
 

--- a/text/0000-variable-size-kernels.md
+++ b/text/0000-variable-size-kernels.md
@@ -1,0 +1,112 @@
+
+- Title: variable-size-kernels
+- Authors: [Antioch Peverell](mailto:apeverell@protonmail.com)
+- Start date : Aug 13, 2019
+- RFC PR: Edit if merged: [mimblewimble/grin-rfcs#0000](https://github.com/mimblewimble/grin-rfcs/pull/0000)
+- Tracking issue: [Edit if merged with link to tracking github issue]
+
+---
+
+# Summary
+[summary]: #summary
+
+We propose minimizing the serialized kernel data by only including data applicable for each kernel feature variant.
+i.e. Only include a lock_height on height locked kernels and do not include a fee on coinbase kernels.
+
+# Motivation
+[motivation]: #motivation
+
+We currently include both the fee and the lock_height on _every_ kernel in binary serialization format.
+We store a fee of 0 on coinbase kernels and a lock_height of 0 on plain and coinbase kernels.
+Kernels are never pruned and exist forever. This data is unnecessary and must be stored indefinitely and
+sent to peers during initial fast sync.
+This will reduce the total size of the kernels in binary serialized format, reducing local storage costs and reducing
+the amount of data necessary for initial fast sync.
+
+# Community-level explanation
+[community-level-explanation]: #community-level-explanation
+
+Transaction kernels currently have several pieces of "optional" data that are only applicable for particular kernel feature variants. Coinbase kernels do not have an associated fee and height locked kernels are the only kernels that have an associated lock_height. We currently implement these by always including these values but using 0 if not applicable.
+
+These are both serialized as 8 bytes (u64) making serialization/deserialization simple but at the cost of unneccessary data that is effectively ignored.
+
+As the number of kernels continues to grow over time this unneccessary data becomes ever more expensive.
+
+By not serializing a zero value for the lock_height on _every_ kernel we will save 8 bytes per kernel. This may not seem significant but this saves 8MB for one million plain kernels.
+
+The trade-off is more complex serialization/deserialization rules and additional complexity in terms of backward compatibility across the network to roll this change out.
+
+
+
+
+Explain the proposal as if it were already introduced into the Grin ecosystem and you were teaching it to another community member. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Grin community members should *think* about the improvement, and how it should impact the way they interact with Grin. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Grin community members and new Grin community members.
+
+For implementation-oriented RFCs (e.g. for wallet), this section should focus on how wallet contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For core, node, wallet and infrastructure proposals: Does this feature exist in other projects and what experience have their community had?
+- For community, ecosystem and moderation proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture. If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other projects.
+
+Note that while precedent set by other projects is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that Grin sometimes intentionally diverges from common project features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+# Future possibilities
+[future-possibilities]: #future-possibilities
+
+Think about what the natural extension and evolution of your proposal would be and how it would affect the project and ecosystem as a whole in a holistic way. Try to use this section as a tool to more fully consider all possible interactions with the project and language in your proposal. Also consider how it fits into the road-map of the project and of the relevant sub-team.
+
+This is also a good place to "dump ideas", if they are out of scope for the RFC you are writing but otherwise related.
+
+If you have tried and cannot think of any future possibilities, you may simply state that you cannot think of anything.
+
+Note that having something written down in the future-possibilities section is not a reason to accept the current or a future RFC; such notes should be in the section on motivation or rationale in this or subsequent RFCs. The section merely provides additional information.
+
+# References
+[references]: #references
+
+Include any references such as links to other documents or reference implementations.

--- a/text/0000-variable-size-kernels.md
+++ b/text/0000-variable-size-kernels.md
@@ -10,60 +10,102 @@
 # Summary
 [summary]: #summary
 
-We propose minimizing the serialized kernel data by only including data applicable for each kernel feature variant.
-i.e. Only include a lock_height on height locked kernels and do not include a fee on coinbase kernels.
+We can reduce the amount of data used to serialize transaction kernel in binary format by including only the data applicable for each kernel feature variant. Specifically we only need a lock height on height locked kernels and coinbase kernels have no associated fee. Each kernel feature variant will serialize to a known number of bytes but this size will not be consistent across different feature variants.
 
 # Motivation
 [motivation]: #motivation
 
-We currently include both the fee and the lock_height on _every_ kernel in binary serialization format.
-We store a fee of 0 on coinbase kernels and a lock_height of 0 on plain and coinbase kernels.
-Kernels are never pruned and exist forever. This data is unnecessary and must be stored indefinitely and
-sent to peers during initial fast sync.
-This will reduce the total size of the kernels in binary serialized format, reducing local storage costs and reducing
-the amount of data necessary for initial fast sync.
+We currently include both the fee and the lock_height on _every_ kernel in binary serialization format. We store a fee of 0 on coinbase kernels and a lock_height of 0 on plain and coinbase kernels. Kernels are never pruned and exist forever so this overhead is relatively expensive. By only serializing data strictly necessary for each kernel feature variant we reduce data storage and transmission costs. This change will also introduce the flexibility necessary to more easily introduce future kernel variants, for example the proposed [relative kernels][0].
 
 # Community-level explanation
 [community-level-explanation]: #community-level-explanation
 
-Transaction kernels currently have several pieces of "optional" data that are only applicable for particular kernel feature variants. Coinbase kernels do not have an associated fee and height locked kernels are the only kernels that have an associated lock_height. We currently implement these by always including these values but using 0 if not applicable.
+Each transaction kernel feature variant may have some associated data. For example height locked kernels include an associated lock height and plain kernels have an associated fee. Coinbase kernels have no associated fee nor lock height. Binary serialization of each kernel feature variant produces a fixed size in bytes but this size may differ across different feature variants. This allows kernels to be serialized efficiently in terms of size in bytes and also provides flexibility to introduce new kernel variants that have additional associated data in the future.
 
-These are both serialized as 8 bytes (u64) making serialization/deserialization simple but at the cost of unneccessary data that is effectively ignored.
+To illustrate the benfit of saving a few bytes, we observe that 8 bytes are used to serialize the transaction fee. By not including 8 bytes for the fee on coinbase kernels we save 8,000,000 bytes of unneccesary data over one million coinbase kernels.
 
-As the number of kernels continues to grow over time this unneccessary data becomes ever more expensive.
-
-By not serializing a zero value for the lock_height on _every_ kernel we will save 8 bytes per kernel. This may not seem significant but this saves 8MB for one million plain kernels.
-
-The trade-off is more complex serialization/deserialization rules and additional complexity in terms of backward compatibility across the network to roll this change out.
-
-
-
-
-Explain the proposal as if it were already introduced into the Grin ecosystem and you were teaching it to another community member. That generally means:
-
-- Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how Grin community members should *think* about the improvement, and how it should impact the way they interact with Grin. It should explain the impact as concretely as possible.
-- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing Grin community members and new Grin community members.
-
-For implementation-oriented RFCs (e.g. for wallet), this section should focus on how wallet contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+These changes affect serialization/deserialization of transaction kernels and these are included in several p2p messages, including transactions, full blocks and compact blocks. We need to be careful with the rollout of these changes to ensure backward compatibility across nodes on the network. The kernel MMR is received as part of the initial state sync so care must be taken here to ensure all nodes can continue to sync successfully when joining the network.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
+In protocol version 1 all transaction kernels are serialized using the same structure, regardless of kernel variant. All kernels include 8 bytes for the fee and 8 bytes for the lock_height, even if unused.
 
-- Its interaction with other features is clear.
-- It is reasonably clear how the feature would be implemented.
-- Corner cases are dissected by example.
+```
+features (1 byte) | fee (8 bytes) | lock_height (8 bytes) | excess (32 bytes) | signature (64 bytes)
 
-The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+00 | 00 00 00 00 01 f7 8a 40 | 00 00 00 00 00 00 00 00 | 08 b1 ... 22 d8 | 33 11 ... b9 69
+```
 
-# Drawbacks
-[drawbacks]: #drawbacks
+All kernels contain a feature byte to determine the variant. Kernels always include an excess commitment and signature, 32 bytes and 64 bytes respectively. The proposal is to have variant specific data follow the feature byte.
 
-Why should we *not* do this?
+The initial feature byte would determine the number of subsequent bytes to read for variant specific data.
+
+```
+00 (plain): following 8 bytes for the fee.
+01 (coinbase): no additional bytes.
+02 (height locked): following 8 bytes for the fee and additional 8 bytes for the lock height.
+```
+
+This would always be followed by a fixed 32 bytes for the excess commitment and 64 bytes for the kernel signature.
+
+----
+
+Proposed plain kernel (protocol version 2) -
+
+```
+features (1 byte) | fee (8 bytes) | excess (32 bytes) | signature (64 bytes)
+
+00 | 00 00 00 00 01 f7 8a 40 | 08 b1 ... 22 d8 | 33 11 ... b9 69
+```
+
+Proposed coinbase kernel (protocol version 2) -
+
+```
+features (1 byte) | excess (32 bytes) | signature (64 bytes)
+
+01 | 08 b2 ... 15 36 | 08 14 ... 98 96
+```
+
+Proposed height locked kernel (protocol version 2) -
+
+```
+features (1 byte) | fee (8 bytes) | lock_height (8 bytes) | excess (32 bytes) | signature (64 bytes)
+
+02 | 00 00 00 00 00 6a cf c0 | 00 00 00 00 00 00 04 14 | 09 4d ... bb 9a | 09 c7 ... bd 54
+```
+
+----
+
+#### Backward Compatibility (Protocol Version Support)
+
+[wip] Discuss compatibility between nodes across protocol version 1 and protocol version 2. Both for transaction and block p2p messages and the less flexible heavyweight txhashset.zip
+
+How do we structure compatibility rules here to ensure nodes can still successfully communicate if bytes appear to be missing etc.
+
+We also need to account for in-place migration. Full blocks are stored in the local database.
+
+Each node maintains a local kernel MMR - but this is also used to generate txhashset.zip which is sent to other nodes, so not limited to local node.
+
+----
+
+#### Wallet Compatibility
+
+Interactive transaction building involves passing a transaction "slate" around. This includes a json serialized representation of the transaction.
+
+To minimize compatibility issues between walets we are not planning to change this json format or structure. Transaction kernels will continue to be translated to a single consistent json format, always including values for both fee and lock_height, regardless of feature variant. For example plain kernels will always have lock_height of 0 and coinbase kernels will always have 0 fee. This is consistent with the current "v2" slate.
+
+```
+"kernels": [
+  {
+	"features": "Plain",
+	"fee": "7000000",
+	"lock_height": "0",
+	"excess": "08b1...22d8",
+	"excess_sig": "3311...b969"
+  }
+]
+```
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -72,41 +114,14 @@ Why should we *not* do this?
 - What other designs have been considered and what is the rationale for not choosing them?
 - What is the impact of not doing this?
 
-# Prior art
-[prior-art]: #prior-art
-
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
-
-- For core, node, wallet and infrastructure proposals: Does this feature exist in other projects and what experience have their community had?
-- For community, ecosystem and moderation proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
-
-This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture. If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other projects.
-
-Note that while precedent set by other projects is some motivation, it does not on its own motivate an RFC.
-Please also take into consideration that Grin sometimes intentionally diverges from common project features.
-
-# Unresolved questions
-[unresolved-questions]: #unresolved-questions
-
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
-
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would be and how it would affect the project and ecosystem as a whole in a holistic way. Try to use this section as a tool to more fully consider all possible interactions with the project and language in your proposal. Also consider how it fits into the road-map of the project and of the relevant sub-team.
-
-This is also a good place to "dump ideas", if they are out of scope for the RFC you are writing but otherwise related.
-
-If you have tried and cannot think of any future possibilities, you may simply state that you cannot think of anything.
-
-Note that having something written down in the future-possibilities section is not a reason to accept the current or a future RFC; such notes should be in the section on motivation or rationale in this or subsequent RFCs. The section merely provides additional information.
+One motivation for "variable size kernels" is to allow for new kernel variants to be introduced in the future. One concrete exampe of this is the proposal for [relative kernels][0]. Kernels of this feature variant will have an associated reference to a prior kernel and the existing "fixed size" binary serialization format does not provide the flexibility to include this additional data.
 
 # References
 [references]: #references
 
-Include any references such as links to other documents or reference implementations.
+* [RFC 0000-relative-kernels][0] [fix link once RFC merged]
+
+[0]: https://github.com/mimblewimble/grin-rfcs/blob/master/text/0000-relative-kernels.md

--- a/text/0005-variable-size-kernels.md
+++ b/text/0005-variable-size-kernels.md
@@ -1,9 +1,9 @@
 
-- Title: variable-size-kernels
+- Title: `variable-size-kernels`
 - Authors: [Antioch Peverell](mailto:apeverell@protonmail.com)
 - Start date: Aug 13, 2019
-- RFC PR: Edit if merged: [mimblewimble/grin-rfcs#0000](https://github.com/mimblewimble/grin-rfcs/pull/0000)
-- Tracking issue: [Edit if merged with link to tracking github issue]
+- RFC PR: [mimblewimble/grin-rfcs#21](https://github.com/mimblewimble/grin-rfcs/pull/21)
+- Tracking issue: [mimblewimble/grin#3038](https://github.com/mimblewimble/grin/issues/3038)
 
 ---
 

--- a/text/0005-variable-size-kernels.md
+++ b/text/0005-variable-size-kernels.md
@@ -120,7 +120,7 @@ Each node maintains a kernel MMR as part of the txhashset data structure. Each n
 
 Internally nodes are free to use any protocol version but the kernel MMR is also provided to other nodes during initial fast sync. A node joining the network requests a txhashset state file and this includes the kernel MMR. It is important that nodes send and receive the txhashset file using a compatible protocol version. This is a special case of "p2p messages" above with the txhashset state file provided as an attachment to the txhashset message.
 
-If node A (protocol version 2) requests a txhashset from node B (protocol version 1) then it must read the file using protocol version 1. Similarly if node B requests txhashset from node A then node A must provide the file such that it is compatible with protocol version 1.
+If node A (protocol version 2) requests a txhashset from node B (protocol version 1) then it must read the file using protocol version 1. Similarly, if node B requests txhashset from node A then node A must provide the file such that it is compatible with protocol version 1.
 
 The simplest way to achieve this is for all nodes to continue to use protocol version 1 internally for MMR storage, even if they use protocol version 2 externally for p2p messages. A transition period will be in place until a majority of nodes support protocol version 2 at which time nodes can migrate their MMR storage to protocol version 2.
 
@@ -146,7 +146,7 @@ To minimize compatibility issues between wallets we have maintained this existin
 # Future possibilities
 [future-possibilities]: #future-possibilities
 
-Support for variable size kernels allows new kernel variants to be introduced in the future. One concrete exampe of this is [relative kernels][0]. Kernels with relative lock heights will have an associated reference to a prior kernel in addition to a lock height based on that prior kernel.
+Support for variable size kernels allows new kernel variants to be introduced in the future. One concrete example of this is [relative kernels][0]. Kernels with relative lock heights will have an associated reference to a prior kernel in addition to a lock height based on that prior kernel.
 
 # References
 [references]: #references


### PR DESCRIPTION
[Rendered link to RFC document](https://github.com/antiochp/grin-rfcs/blob/variable_size_kernels/text/0000-variable-size-kernels.md)

This is a pre-requisite for "relative kernels" as we need to be able to introduce new kernel feature variants, with additional associated data.

The proposal is to support kernels of variable size, with each kernel variant supporting additional data specific to the variant. Height locked kernels have an associated lock height for example.

