### PR TITLE
Retire RFCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,24 @@ To begin writing your own RFC or to find out more about the process and the gene
 
 ## List of accepted RFCs
 
-|Title|Tl;dr|
-|:---|:---|
-| [0001-rfc-process](text/0001-rfc-process.md) | Introduce RFC process |
-| [0002-grin-governance](text/0002-grin-governance.md) | Articulate community values, define core and sub-teams |
-| [0003-security-process](text/0003-security-process.md) | Define community standards for ethical disclosure behaviour |
-| [0004-full-wallet-lifecycle](text/0004-full-wallet-lifecycle.md) | Define API standard for sensitive wallet operations |
-| [0005-variable-size-kernels](text/0005-variable-size-kernels.md) | Introduce kernel variants that can be of different sizes |
-| [0006-payment-proofs](text/0006-payment-proofs.md) | Support generating and validating payment proofs for sender-initiated (i.e. non-invoice) transactions |
-| [0007-node-api-v2](text/0007-node-api-v2.md) | Create a v2 JSON-RPC API for the Node API |
-| [0008-wallet-state-management](text/0008-wallet-state-management.md) | Improve wallet state management |
-| [0009-enable-faster-sync](text/0009-enable-faster-sync.md) | Enable faster txhashset sync by changing output MMR commitment |
-| [0010-online-transacting-via-tor](text/0010-online-transacting-via-tor.md) | Define standard for transacting via Tor |
-| [0011-security-team](text/0011-security-team.md) | Establish Grin Security team |
-| [0012-compact-slates](text/0012-compact-slates.md) | Introduce new compact slate format (Slate V4) |
-| [0013-nrd-kernels](text/0013-nrd-kernels.md) | Introduce relative timelocks through "No Recent Duplicate" transaction kernels |
-| [0014-general-fund-guidelines](text/0014-general-fund-guidelines.md) | Define general fund spending guidelines |
-| [0015-slatepack](text/0015-slatepack.md) | Universal transaction standard for Grin |
-| [0016-simplify-governance](text/0016-simplify-governance.md) | Simplify Grin governance model |
+|Title|Status|Tl;dr|
+|:---|---|:---|
+| [0001-rfc-process](text/0001-rfc-process.md) | ACTIVE | Introduce RFC process |
+| [0002-grin-governance](text/0002-grin-governance.md) | RETIRED | ~~Articulate community values, define core and sub-teams~~ Replaced by RFC#6. |
+| [0003-security-process](text/0003-security-process.md) | ACTIVE | Define community standards for ethical disclosure behaviour |
+| [0004-full-wallet-lifecycle](text/0004-full-wallet-lifecycle.md) | ACTIVE | Define API standard for sensitive wallet operations |
+| [0005-variable-size-kernels](text/0005-variable-size-kernels.md) | ACTIVE | Introduce kernel variants that can be of different sizes |
+| [0006-payment-proofs](text/0006-payment-proofs.md) | ACTIVE | Support generating and validating payment proofs for sender-initiated (i.e. non-invoice) transactions |
+| [0007-node-api-v2](text/0007-node-api-v2.md) | ACTIVE | Create a v2 JSON-RPC API for the Node API |
+| [0008-wallet-state-management](text/0008-wallet-state-management.md) | ACTIVE | Improve wallet state management |
+| [0009-enable-faster-sync](text/0009-enable-faster-sync.md) | ACTIVE | Enable faster txhashset sync by changing output MMR commitment |
+| [0010-online-transacting-via-tor](text/0010-online-transacting-via-tor.md) | RETIRED | ~~Define standard for transacting via Tor~~ Replaced by RFC#0015. |
+| [0011-security-team](text/0011-security-team.md) | ACTIVE | Establish Grin Security team |
+| [0012-compact-slates](text/0012-compact-slates.md)| ACTIVE | Introduce new compact slate format (Slate V4) |
+| [0013-nrd-kernels](text/0013-nrd-kernels.md) | ACTIVE | Introduce relative timelocks through "No Recent Duplicate" transaction kernels |
+| [0014-general-fund-guidelines](text/0014-general-fund-guidelines.md) | ACTIVE | Define general fund spending guidelines |
+| [0015-slatepack](text/0015-slatepack.md) | ACTIVE | Universal transaction standard for Grin. Replaces RFC#0010. |
+| [0016-simplify-governance](text/0016-simplify-governance.md) | ACTIVE | Simplify Grin governance model. Replaces RFC#0002. |
 
 ## License
 

--- a/text/0002-grin-governance.md
+++ b/text/0002-grin-governance.md
@@ -6,6 +6,11 @@
 
 ---
 
+## RETIRED
+This RFC has been retired and has been superseded by [RFC#0016: simplify-governance](text/0016-simplify-governance.md).
+
+---
+
 ## Summary
 [summary]: #summary
 

--- a/text/0010-online-transacting-via-tor.md
+++ b/text/0010-online-transacting-via-tor.md
@@ -7,6 +7,11 @@
 
 ---
 
+## RETIRED
+This RFC has been retired and has been superseded by [RFC#0015: slatepack](text/0015-slatepack.md).
+
+---
+
 ## Summary
 [summary]: #summary
 


### PR DESCRIPTION
1. Adds "status" column to readme's list of RFCs, current possible states (for now):
   - Active
   - Retired
1. Retire RFC#010 "online-transacting-via-tor" in favour of RFC#0015 "slatepack"
1. Retire RFC#002 "governance" in favour of RFC#0016 "simplify-governance"
