### PR TITLE
Fix broken links

### DIFF
--- a/.github/workflows/markdown-links.config.json
+++ b/.github/workflows/markdown-links.config.json
@@ -1,0 +1,7 @@
+{
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 5,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206]
+}

--- a/.github/workflows/markdown-links.config.json
+++ b/.github/workflows/markdown-links.config.json
@@ -3,5 +3,10 @@
   "retryOn429": true,
   "retryCount": 5,
   "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 206]
+  "aliveStatusCodes": [200, 206],
+  "ignorePatterns": [
+    {
+      "pattern": "https://github.com/mimblewimble/grin-rfcs/pull/0000"
+    }
+  ]
 }

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -1,0 +1,14 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        config-file: '.github/workflows/markdown-links.config.json'

--- a/0000-template.md
+++ b/0000-template.md
@@ -2,7 +2,7 @@
 - Title: [edit and replace with a unique name like so: `my-awesome-proposal`]
 - Authors: [Your Name](mailto:your@email.com)
 - Start date: [edit and replace the day work begun, i.e. `Jan 15, 2019`]
-- RFC PR: Edit if merged: [mimblewimble/grin-rfcs#0000](https://github.com/mimblewimble/grin-rfcs/pull/0000)
+- RFC PR: Edit if merged: [mimblewimble/grin-rfcs#0000](https://github.com/mimblewimble/grin-rfcs/pulls/0000)
 - Tracking issue: [Edit if merged with link to tracking github issue]
 
 ---

--- a/0000-template.md
+++ b/0000-template.md
@@ -2,7 +2,7 @@
 - Title: [edit and replace with a unique name like so: `my-awesome-proposal`]
 - Authors: [Your Name](mailto:your@email.com)
 - Start date: [edit and replace the day work begun, i.e. `Jan 15, 2019`]
-- RFC PR: Edit if merged: [mimblewimble/grin-rfcs#0000](https://github.com/mimblewimble/grin-rfcs/pulls/0000)
+- RFC PR: Edit if merged: [mimblewimble/grin-rfcs#0000](https://github.com/mimblewimble/grin-rfcs/pull/0000)
 - Tracking issue: [Edit if merged with link to tracking github issue]
 
 ---

--- a/0000-template.md
+++ b/0000-template.md
@@ -92,5 +92,5 @@ Note that having something written down in the future-possibilities section is n
 
 Include any references such as links to other documents or reference implementations.
 
-- [reference 1](link)
-- [reference 2](link)
+- [reference 1](#references)
+- [reference 2](#references)

--- a/text/0002-grin-governance.md
+++ b/text/0002-grin-governance.md
@@ -7,7 +7,7 @@
 ---
 
 ## RETIRED
-This RFC has been retired and has been superseded by [RFC#0016: simplify-governance](text/0016-simplify-governance.md).
+This RFC has been retired and has been superseded by [RFC#0016: simplify-governance](0016-simplify-governance.md).
 
 ---
 
@@ -183,7 +183,6 @@ Far too many to all be listed here, but here are some:
 **Rust's governance process**
 
 - [https://rust-lang.github.io/rfcs/1068-rust-governance.html](https://rust-lang.github.io/rfcs/1068-rust-governance.html)
-- [https://predictablynoisy.com/rust-governance](https://predictablynoisy.com/rust-governance)
 - [http://mgattozzi.com/oss-governance-and-sustainablility-i/](http://mgattozzi.com/oss-governance-and-sustainablility-i/)
 
 **Node.js governance**

--- a/text/0002-grin-governance.md
+++ b/text/0002-grin-governance.md
@@ -183,6 +183,7 @@ Far too many to all be listed here, but here are some:
 **Rust's governance process**
 
 - [https://rust-lang.github.io/rfcs/1068-rust-governance.html](https://rust-lang.github.io/rfcs/1068-rust-governance.html)
+- [https://web.archive.org/web/2019*/https://predictablynoisy.com/rust-governance](https://web.archive.org/web/2019*/https://predictablynoisy.com/rust-governance)
 - [http://mgattozzi.com/oss-governance-and-sustainablility-i/](http://mgattozzi.com/oss-governance-and-sustainablility-i/)
 
 **Node.js governance**

--- a/text/0003-security-process.md
+++ b/text/0003-security-process.md
@@ -54,7 +54,7 @@ from the beginning to the community, vulnerability researchers, the core team
 and other neighboring projects that share threads in the same security blanket.
 
 An example of another project adopting the same standard can be found
-[here](https://github.com/zcash/zcash/blob/master/responsible_disclosure.md)
+[here](https://github.com/zcash/zcash/blob/76d3adc564a8cb87923ce5be1cc3aa8046f6d24e/SECURITY.md)
 in Zcash's vulnerability disclosure document.
 
 ## Reference-level explanation
@@ -66,7 +66,7 @@ in Zcash's vulnerability disclosure document.
 [SECURITY.md](https://github.com/mimblewimble/grin/blob/09cf6de1d143ffbe007478372dc573213e06804d/SECURITY.md) if the RFC is adopted.
 
 - Many of the changes proposed are modeled from
-[Zcash's security disclosure policy](https://github.com/zcash/zcash/blob/master/responsible_disclosure.md#security-disclosures)
+[Zcash's security disclosure policy](https://github.com/zcash/zcash/blob/76d3adc564a8cb87923ce5be1cc3aa8046f6d24e/SECURITY.md#security-disclosures)
 which adopts the same standard proposed here for Grin.
 
 _All links to the standard in the actual implementation of SECURITY.md must be
@@ -336,7 +336,7 @@ relevant to the security process for Grin.
 - [0] [https://dl.packetstormsecurity.net/papers/general/rfpolicy-2.0.txt](https://dl.packetstormsecurity.net/papers/general/rfpolicy-2.0.txt)
 - [1] [https://www.youtube.com/watch?v=h7W1u1K2VjQ](https://www.youtube.com/watch?v=h7W1u1K2VjQ)
 - [2] [https://github.com/RD-Crypto-Spec/Responsible-Disclosure](https://github.com/RD-Crypto-Spec/Responsible-Disclosure)
-- [3] [https://github.com/zcash/zcash/blob/master/responsible_disclosure.md](https://github.com/zcash/zcash/blob/master/responsible_disclosure.md)
+- [3] [https://github.com/zcash/zcash/blob/master/SECURITY.md](https://github.com/zcash/zcash/blob/76d3adc564a8cb87923ce5be1cc3aa8046f6d24e/SECURITY.md)
 - [4] [https://github.com/mimblewimble/grin/blob/09cf6de1d143ffbe007478372dc573213e06804d/SECURITY.md](https://github.com/mimblewimble/grin/blob/09cf6de1d143ffbe007478372dc573213e06804d/SECURITY.md)
 - [5] [https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-020-2019.txt](https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-020-2019.txt)
 - [6] [https://riseup.net/about-us/canary/canary-statement-signed.txt](https://riseup.net/about-us/canary/canary-statement-signed.txt)

--- a/text/0007-node-api-v2.md
+++ b/text/0007-node-api-v2.md
@@ -59,7 +59,7 @@ Create a v2 JSON-RPC API for the Node API.
 
 The previous Node API (referred to here as v1) was a REST API. This API while simple had a few drawbacks:
 
-- Manually documented (current documentation is available [here](https://github.com/mimblewimble/grin/blob/master/doc/api/node_api.md).
+- Manually documented (current documentation is available [here](https://github.com/mimblewimble/grin/blob/master/doc/api/node_api_v1.md).
 - Contains call with heterogenous args such as `?byid=xxx` and `commitment/xxx` which can be confusing and lack some uniformity.
 - Uses REST which is bound to HTTP while v2 wallet API uses JSON-RPC.
 - No difference between node management and simple information endpoints (i.e. exposing the node on the internet would allow anyone to query sensitive endpoints)
@@ -81,7 +81,7 @@ This new API will be particularly useful for wallet developer and should ultimat
 
 ### V1 Endpoints
 
-While the endpoints are documented in details [here](https://github.com/mimblewimble/grin/blob/master/doc/api/node_api.md), here is an overview of the REST API Endpoints of the v1 API.
+While the endpoints are documented in details [here](https://github.com/mimblewimble/grin/blob/master/doc/api/node_api_v1.md), here is an overview of the REST API Endpoints of the v1 API.
 
 ```JSON
 [
@@ -1108,7 +1108,7 @@ This kind of JSON-RPC API is widely used for cryptocurrencies. For instance:
 - [Bitcoin](https://en.bitcoin.it/wiki/API_reference_\(JSON-RPC\))
 - [Ethereum](https://github.com/ethereum/wiki/wiki/JSON-RPC)
 - [Monero](https://web.getmonero.org/resources/developer-guides/wallet-rpc.html)
-- [Tezos](https://tezos.gitlab.io/master/developer/rpc.html)
+- [Tezos](https://tezos.gitlab.io/developer/rpc.html)
 
 ## Future possibilities
 [future-possibilities]: #future-possibilities
@@ -1122,4 +1122,4 @@ This API simplifies the deployment of new methods and drastically simplifies the
 - [Bitcoin JSON-RPC Doc](https://en.bitcoin.it/wiki/API_reference_\(JSON-RPC\))
 - [Ethereum JSON-RPC Doc](https://github.com/ethereum/wiki/wiki/JSON-RPC)
 - [Monero JSON-RPC Doc](https://web.getmonero.org/resources/developer-guides/wallet-rpc.html)
-- [Tezos JSON-RPC Doc](https://tezos.gitlab.io/master/developer/rpc.html)
+- [Tezos JSON-RPC Doc](https://tezos.gitlab.io/developer/rpc.html)

--- a/text/0009-enable-faster-sync.md
+++ b/text/0009-enable-faster-sync.md
@@ -3,7 +3,7 @@
 - Authors: [Antioch Peverell](mailto:apeverell@protonmail.com), [John Tromp](mailto:john.tromp@gmail.com)
 - Start date: Oct 25, 2019
 - RFC PR: [mimblewimble/grin-rfcs#29](https://github.com/mimblewimble/grin-rfcs/pull/29)
-
+- Tracking issue: [mimblewimble/grin#3173](https://github.com/mimblewimble/grin/issues/3173)
 ---
 
 ## Summary

--- a/text/0009-enable-faster-sync.md
+++ b/text/0009-enable-faster-sync.md
@@ -4,6 +4,7 @@
 - Start date: Oct 25, 2019
 - RFC PR: [mimblewimble/grin-rfcs#29](https://github.com/mimblewimble/grin-rfcs/pull/29)
 - Tracking issue: [mimblewimble/grin#3173](https://github.com/mimblewimble/grin/issues/3173)
+
 ---
 
 ## Summary

--- a/text/0009-enable-faster-sync.md
+++ b/text/0009-enable-faster-sync.md
@@ -3,7 +3,6 @@
 - Authors: [Antioch Peverell](mailto:apeverell@protonmail.com), [John Tromp](mailto:john.tromp@gmail.com)
 - Start date: Oct 25, 2019
 - RFC PR: [mimblewimble/grin-rfcs#29](https://github.com/mimblewimble/grin-rfcs/pull/29)
-- Tracking issue: [mimblewimble/grin-wallet#3173](https://github.com/mimblewimble/grin-wallet/issues/3173)
 
 ---
 

--- a/text/0010-online-transacting-via-tor.md
+++ b/text/0010-online-transacting-via-tor.md
@@ -8,7 +8,7 @@
 ---
 
 ## RETIRED
-This RFC has been retired and has been superseded by [RFC#0015: slatepack](text/0015-slatepack.md).
+This RFC has been retired and has been superseded by [RFC#0015: slatepack](0015-slatepack.md).
 
 ---
 

--- a/text/0012-compact-slates.md
+++ b/text/0012-compact-slates.md
@@ -484,6 +484,6 @@ value of the `feat` field. Currently only present if `feat` is 2.
 
 This RFC is envisaged as a necessary first step for all slate-exchange possibilities that would benefit from compactness, e.g:
 
-* [Slatepack](https://github.com/j01tz/grin-rfcs/blob/slatepack/text/0000-slatepack.md)
+* Slatepack
 * QR Code encoding of slates
 * Armored slates

--- a/text/0014-general-fund-guidelines.md
+++ b/text/0014-general-fund-guidelines.md
@@ -35,7 +35,7 @@ Although spending decisions will always be made on a case-by-case basis, it is u
 
 There is scope for interpretation as to what this actually means, but the following presents (non-exhaustive) guidelines as to the types of activities that would be considered appropriate to finance from the fund.
 
-* Activities related to the continuing development needs of the Grin code-base and related projects under the GitHub [mimblewimble](github.com/mimblewimble) organization. This can include:
+* Activities related to the continuing development needs of the Grin code-base and related projects under the GitHub [mimblewimble](https://github.com/mimblewimble) organization. This can include:
    * Fixed-term development or project-management contracts
    * Infrastructure and other incidental costs
    * Security audit costs


### PR DESCRIPTION
@quentinlesceller Follow up on the discussion at https://github.com/mimblewimble/docs/pull/59

The repository contained a large amount of dead or broken links. Dead links with no clear up-to-date reference have been removed, while broken links were fixed. CI check that looks for broken links has been added.